### PR TITLE
Resolve long-standing bug in long-chain computation

### DIFF
--- a/longestArray.py
+++ b/longestArray.py
@@ -9,14 +9,14 @@ class recursion():
 
     def run(self):
         #runs all values from n_start and self terminates when reaching n_end
+        highestCycleVal=0
+        CycleVal=0
+        val = []
         while self.n_start != self.n_end:
             endSequenceCheck = True
             output = colCon().run_iteration(self.n_start)
             
             endSequenceCheck = True
-            highestCycleVal=0
-            CycleVal=0
-            val = []
             for i in range(3):
                 if output[-(i+1)] == 4 or 2 or 1:
                     pass
@@ -29,7 +29,7 @@ class recursion():
                 val = output
                 
             self.n_start += 1
-        print(f"the highest cycle value reached was {highestCycleVal}, which was in iteration {cycleVal}, holding the value of {output}")
+        print(f"the highest cycle value reached was {highestCycleVal}, which was in iteration {cycleVal}, holding the value of {val}")
 
     
 if __name__ == "__main__":


### PR DESCRIPTION
This update should resolve two bugs in the longestChain routine:

1. the running "maximum-length" variable was getting reset to zero in each iteration of the loop; and
2. the print-statement was printing an unhelpful value; if I understand correctly, it had been printing the *highest index's Collatz chain array*, i.e., whatever the most recently computed chain was, rather than printing the **longest** chain it ever encountered among all the indices from lowest to highest.

As always, any questions and feedback are welcome.